### PR TITLE
(Some) Native JS types & IE11 fix

### DIFF
--- a/objectAssignDeep.js
+++ b/objectAssignDeep.js
@@ -43,7 +43,7 @@ function getTypeOf (input) {
  */
 function cloneValue (value) {
 
-	const valueType = getTypeOf(value);
+	var valueType = getTypeOf(value);
 
 	// The value is an object so lets clone it.
 	if (valueType === 'object') {
@@ -81,7 +81,7 @@ function quickCloneArray (input) {
  */
 function quickCloneObject (input) {
 
-	const output = {};
+	var output = {};
 
 	for (const key in input) {
 		if (!input.hasOwnProperty(key)) { continue; }
@@ -98,28 +98,28 @@ function quickCloneObject (input) {
  */
 function executeDeepMerge (target, _objects = [], _options = {}) {
 
-	const options = {
+	var options = {
 		arrayBehaviour: _options.arrayBehaviour || 'replace',  // Can be "merge" or "replace".
 	};
 
 	// Ensure we have actual objects for each.
-	const objects = _objects.map(object => object || {});
-	const output = target || {};
+	var objects = _objects.map(object => object || {});
+	var output = target || {};
 
 	// Enumerate the objects and their keys.
 	for (let oindex = 0; oindex < objects.length; oindex++) {
-		const object = objects[oindex];
-		const keys = Object.keys(object);
+		var object = objects[oindex];
+		var keys = Object.keys(object);
 
 		for (let kindex = 0; kindex < keys.length; kindex++) {
-			const key = keys[kindex];
-			const value = object[key];
-			const type = getTypeOf(value);
-			const existingValueType = getTypeOf(output[key]);
+			var key = keys[kindex];
+			var value = object[key];
+			var type = getTypeOf(value);
+			var existingValueType = getTypeOf(output[key]);
 
 			if (type === 'object') {
 				if (existingValueType !== 'undefined') {
-					const existingValue = (existingValueType === 'object' ? output[key] : {});
+					var existingValue = (existingValueType === 'object' ? output[key] : {});
 					output[key] = executeDeepMerge({}, [existingValue, quickCloneObject(value)], options);
 				}
 				else {
@@ -129,7 +129,7 @@ function executeDeepMerge (target, _objects = [], _options = {}) {
 
 			else if (type === 'array') {
 				if (existingValueType === 'array') {
-					const newValue = quickCloneArray(value);
+					var newValue = quickCloneArray(value);
 					output[key] = (options.arrayBehaviour === 'merge' ? output[key].concat(newValue) : newValue);
 				}
 				else {

--- a/objectAssignDeep.js
+++ b/objectAssignDeep.js
@@ -19,7 +19,19 @@ function getTypeOf (input) {
 	}
 
 	else if (typeof input === 'object') {
-		return (Array.isArray(input) ? 'array' : 'object');
+		if (Array.isArray(input)) {
+			return 'array';
+		}
+
+		if (input instanceof Date) {
+			return 'date';
+		}
+
+		if (input instanceof File) {
+			return 'file';
+		}
+
+		return 'object';
 	}
 
 	return typeof input;
@@ -31,14 +43,24 @@ function getTypeOf (input) {
  */
 function cloneValue (value) {
 
+	const valueType = getTypeOf(value);
+
 	// The value is an object so lets clone it.
-	if (getTypeOf(value) === 'object') {
+	if (valueType === 'object') {
 		return quickCloneObject(value);
 	}
 
 	// The value is an array so lets clone it.
-	else if (getTypeOf(value) === 'array') {
+	else if (valueType === 'array') {
 		return quickCloneArray(value);
+	}
+
+	else if (valueType === 'date') {
+		return new Date(value.valueOf());
+	}
+
+	else if (valueType === 'file') {
+		return new File([value], value.name, { type: value.type });
 	}
 
 	// Any other value can just be copied.


### PR DESCRIPTION
* Swap out `const` for `var` for IE11 :(
* Add support for making copies of File and Date objects

We were already using a fork of the original that had been fixed for IE11, so we should be able to publish this under `@ayogohealth/Object-Assign-Deep` and get the File/Date fixes