### PR TITLE
Cordova file plugin file cloning workaround

### DIFF
--- a/objectAssignDeep.js
+++ b/objectAssignDeep.js
@@ -27,7 +27,8 @@ function getTypeOf (input) {
 			return 'date';
 		}
 
-		if (input instanceof File) {
+		// Second condition used to workaround Cordova File plugin redefining 'File')
+		if ((input instanceof File) || (input.toString() === '[object File]')) {
 			return 'file';
 		}
 


### PR DESCRIPTION
The Cordova file plugin redefines ‘File’ causing this check to fail